### PR TITLE
fix: fix incompatible receiver exception on chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: node_js
 node_js:
-  - "6"
-addons:
-  firefox: "49.0"
+  - "stable"
+services:
+  - xvfb
 install:
   - npm install
 before_script:
   - npm install -g grunt
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
-  - echo 'America/Los_Angeles' | sudo tee /etc/timezone
-  - sudo dpkg-reconfigure --frontend noninteractive tzdata
+  - export TZ=America/Los_Angeles
 script: grunt

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "email": "davglass@gmail.com"
     }
   ],
-  "license": "BSD 3-clause",
+  "license": "BSD-3-Clause",
   "description": "Surgically polyfills timezone support in Intl.DateTimeFormat API",
   "main": "build/src/index.js",
   "devDependencies": {

--- a/src/code/polyfill.js
+++ b/src/code/polyfill.js
@@ -48,7 +48,14 @@ function _setPrototypeOf(subClass, superClass) {
     return subClass;
 }
 
+function _isNativeFunction(fn) {
+    return Function.toString.call(fn).indexOf("[native code]") !== -1;
+}  
+
 function _wrapNativeSuper(Class) {
+    if (!_isNativeFunction(Class)) {
+        return Class;
+    }
     function Wrapper() {
         const prototypeConstructor = _getPrototypeOf(this).constructor;
         const args = [null];
@@ -105,7 +112,7 @@ export default function polyfill(globalSpace) {
     const jsonClone = function(o) {
         return JSON.parse(JSON.stringify(o));
     };
-    const _DateTimeFormat = gIntl.DateTimeFormat;
+    const _DateTimeFormat = _wrapNativeSuper(gIntl.DateTimeFormat);
 
     gIntl._DateTimeFormat = _DateTimeFormat;
 
@@ -125,7 +132,7 @@ export default function polyfill(globalSpace) {
         if (options === undefined) {
             // options is not provided. this means
             // we don't need to format arbitrary timezone
-            _this = _getPrototypeOf(DateTimeFormatPolyfill).call(this, locale, options);
+            _this = _DateTimeFormat.call(this, locale, options);
 
             if (_this.formatToParts) {
                 _this._nativeObject = new _DateTimeFormat(locale, options);
@@ -136,7 +143,7 @@ export default function polyfill(globalSpace) {
 
         if (checkTimeZoneSupport(timeZone)) {
             // native method has support for timezone. no polyfill logic needed.
-            _this = _getPrototypeOf(DateTimeFormatPolyfill).call(this, locale, options);
+            _this = _DateTimeFormat.call(this, locale, options);
 
             if (_this.formatToParts) {
                 _this._nativeObject = new _DateTimeFormat(locale, options);
@@ -155,7 +162,7 @@ export default function polyfill(globalSpace) {
         // Do a timeshift to UTC to avoid explosion due to unsupprted timezone.
         const tsOption = jsonClone(options);
         tsOption.timeZone = 'UTC';
-        _this = _getPrototypeOf(DateTimeFormatPolyfill).call(this, locale, tsOption);
+        _this = _DateTimeFormat.call(this, locale, tsOption);
 
         const _resolvedOptions = _get(
             _getPrototypeOf(DateTimeFormatPolyfill.prototype),
@@ -183,7 +190,7 @@ export default function polyfill(globalSpace) {
 
         return _this;
     }
-    _inherits(DateTimeFormatPolyfill, _wrapNativeSuper(_DateTimeFormat));
+    _inherits(DateTimeFormatPolyfill, _DateTimeFormat);
 
     Object.defineProperty(DateTimeFormatPolyfill.prototype, 'format', {
         configurable: true,

--- a/src/code/polyfill.js
+++ b/src/code/polyfill.js
@@ -34,6 +34,43 @@ function _get(object, property, receiver) {
     return getter.call(receiver);
 }
 
+function _getPrototypeOf(Class) {
+    return Object.getPrototypeOf
+        ? Object.getPrototypeOf(Class) 
+        : Class.__proto__;
+}
+
+function _setPrototypeOf(subClass, superClass) {
+    if (Object.setPrototypeOf) {
+        return Object.setPrototypeOf(subClass, superClass);
+    }
+    subClass.__proto__ = superClass;
+    return subClass;
+}
+
+function _wrapNativeSuper(Class) {
+    function Wrapper() {
+        const prototypeConstructor = _getPrototypeOf(this).constructor;
+        const args = [null];
+        args.push.apply(args, arguments);
+        const Constructor = Function.bind.apply(Class, args);
+        const instance = new Constructor();
+        if (prototypeConstructor) {
+            _setPrototypeOf(instance, prototypeConstructor.prototype);
+        }
+        return instance;
+    }
+    Wrapper.prototype = Object.create(Class.prototype, {
+        constructor: {
+            value: Wrapper,
+            enumerable: false,
+            writable: true,
+            configurable: true
+        }
+    });
+    return _setPrototypeOf(Wrapper, Class);
+}
+
 // Also from Babel, minimal subclassing utility function
 function _inherits(subClass, superClass) {
     if (typeof superClass !== "function" && superClass !== null) {
@@ -48,9 +85,7 @@ function _inherits(subClass, superClass) {
         }
     });
     if (superClass) {
-        Object.setPrototypeOf
-            ? Object.setPrototypeOf(subClass, superClass)
-            : subClass.__proto__ = superClass;
+        _setPrototypeOf(subClass, superClass);
     }
 }
 
@@ -83,29 +118,31 @@ export default function polyfill(globalSpace) {
             return new DateTimeFormatPolyfill(locale, options);
         }
 
+        let _this;
+
         const timeZone = (options && options.timeZone) || 'UTC';
 
         if (options === undefined) {
             // options is not provided. this means
             // we don't need to format arbitrary timezone
-            _DateTimeFormat.call(this, locale, options);
+            _this = _getPrototypeOf(DateTimeFormatPolyfill).call(this, locale, options);
 
-            if (this.formatToParts) {
-                this._nativeObject = new _DateTimeFormat(locale, options);
+            if (_this.formatToParts) {
+                _this._nativeObject = new _DateTimeFormat(locale, options);
             }
 
-            return;
+            return _this;
         }
 
         if (checkTimeZoneSupport(timeZone)) {
             // native method has support for timezone. no polyfill logic needed.
-            _DateTimeFormat.call(this, locale, options);
+            _this = _getPrototypeOf(DateTimeFormatPolyfill).call(this, locale, options);
 
-            if (this.formatToParts) {
-                this._nativeObject = new _DateTimeFormat(locale, options);
+            if (_this.formatToParts) {
+                _this._nativeObject = new _DateTimeFormat(locale, options);
             }
 
-            return;
+            return _this;
         }
 
         const timeZoneData = gIntl._timeZoneData.get(timeZone);
@@ -118,16 +155,15 @@ export default function polyfill(globalSpace) {
         // Do a timeshift to UTC to avoid explosion due to unsupprted timezone.
         const tsOption = jsonClone(options);
         tsOption.timeZone = 'UTC';
-        _DateTimeFormat.call(this, locale, tsOption);
+        _this = _getPrototypeOf(DateTimeFormatPolyfill).call(this, locale, tsOption);
 
         const _resolvedOptions = _get(
-            DateTimeFormatPolyfill.prototype.__proto__ ||
-            Object.getPrototypeOf(DateTimeFormatPolyfill.prototype),
+            _getPrototypeOf(DateTimeFormatPolyfill.prototype),
             'resolvedOptions',
-            this
+            _this
         );
 
-        const resolvedLocale = _resolvedOptions.call(this).locale;
+        const resolvedLocale = _resolvedOptions.call(_this).locale;
 
         if (options.timeZoneName !== undefined) {
             // We need to include timeZoneName in date format.
@@ -139,26 +175,26 @@ export default function polyfill(globalSpace) {
         }
 
         // to minimize pollution everything we need to perform polyfill is wrapped under one object.
-        this._dateTimeFormatPolyfill = {
+        _this._dateTimeFormatPolyfill = {
             optionTimeZone: timeZone,
             optionTimeZoneName: options.timeZoneName,
             timeZoneData: timeZoneData
         };
+
+        return _this;
     }
-    _inherits(DateTimeFormatPolyfill, _DateTimeFormat);
+    _inherits(DateTimeFormatPolyfill, _wrapNativeSuper(_DateTimeFormat));
 
     Object.defineProperty(DateTimeFormatPolyfill.prototype, 'format', {
         configurable: true,
         value: function(date) {
             const _format = _get(
-                DateTimeFormatPolyfill.prototype.__proto__ ||
-                Object.getPrototypeOf(DateTimeFormatPolyfill.prototype),
+                _getPrototypeOf(DateTimeFormatPolyfill.prototype),
                 'format',
                 this
             );
             const _resolvedOptions = _get(
-                DateTimeFormatPolyfill.prototype.__proto__ ||
-                Object.getPrototypeOf(DateTimeFormatPolyfill.prototype),
+                _getPrototypeOf(DateTimeFormatPolyfill.prototype),
                 'resolvedOptions',
                 this
             );
@@ -219,8 +255,7 @@ export default function polyfill(globalSpace) {
     });
 
     const _formatToParts = _get(
-      DateTimeFormatPolyfill.prototype.__proto__ ||
-        Object.getPrototypeOf(DateTimeFormatPolyfill.prototype),
+       _getPrototypeOf(DateTimeFormatPolyfill.prototype),
       'formatToParts',
       this
     );
@@ -229,13 +264,11 @@ export default function polyfill(globalSpace) {
         Object.defineProperty(DateTimeFormatPolyfill.prototype, 'formatToParts', {
             configurable: true,
             value: function(date) {
-
                 const _resolvedOptions = _get(
-                  DateTimeFormatPolyfill.prototype.__proto__ ||
-                    Object.getPrototypeOf(DateTimeFormatPolyfill.prototype),
-                  'resolvedOptions',
-                  this
-                );
+                    _getPrototypeOf(DateTimeFormatPolyfill.prototype),
+                   'resolvedOptions',
+                   this
+                 );
 
                 if (!this._dateTimeFormatPolyfill && this._nativeObject) {
                     return this._nativeObject.formatToParts(date);
@@ -288,8 +321,7 @@ export default function polyfill(globalSpace) {
         configurable: true,
         value: function() {
             const _resolvedOptions = _get(
-                DateTimeFormatPolyfill.prototype.__proto__ ||
-                Object.getPrototypeOf(DateTimeFormatPolyfill.prototype),
+                _getPrototypeOf(DateTimeFormatPolyfill.prototype),
                 'resolvedOptions',
                 this
             );


### PR DESCRIPTION
Fixes #36, #37

**Background**: If you try to format some date with timezone which is not supported by the browser (e.g. `CET` on Chrome) but is supported by the polyfill, code throws `Intl.DateTimeFormat.prototype.formatToParts called on incompatible receiver`. This error happens rarely because modern browsers usually provide data for all timezones and they are only ones who care about correct call receiver (that's why it doesn't happen in IE11). 

**Reason**: Polyfill doesn't inherit native class correctly.

**Solution**: In Babel, it was fixed in [this](https://github.com/babel/babel/pull/7020) PR. I've tweaked the code a bit to support IE 10.

**Environment to reproduce the issue** (NB: It should be opened in Chrome): [https://jsfiddle.net/t4q5xk0m/](https://jsfiddle.net/t4q5xk0m/)